### PR TITLE
Update wifi.php

### DIFF
--- a/software/var/www/control/wifi.php
+++ b/software/var/www/control/wifi.php
@@ -155,7 +155,7 @@ Signal Level : <b>' . $strSignalLevel . '</b><br />
 		$ssid = array();
 		$psk = array();
 		foreach($return as $a) {
-			if(preg_match('/SSID/i',$a)) {
+			if(preg_match('/\bSSID/i',$a)) {
 				$arrssid = explode("=",$a);
 				$ssid[] = str_replace('"','',$arrssid[1]);
 			}

--- a/software/var/www/control/wifi.php
+++ b/software/var/www/control/wifi.php
@@ -155,7 +155,7 @@ Signal Level : <b>' . $strSignalLevel . '</b><br />
 		$ssid = array();
 		$psk = array();
 		foreach($return as $a) {
-			if(preg_match('/\bSSID/i',$a)) {
+			if(preg_match('/^\s*SSID/i',$a)) {
 				$arrssid = explode("=",$a);
 				$ssid[] = str_replace('"','',$arrssid[1]);
 			}


### PR DESCRIPTION
Regulären Ausdruck für Suche nach SSIDs in wpa_supplicant.conf. \b  am Anfang hinzugefügt um nur Einträge zu finden, die mit ssid beginnen.
Sonst Konflikt zb mit Eintrag scan_ssid für versteckte SSIDs