### PR TITLE
Remove call to non existing "garden()"

### DIFF
--- a/software/var/www/header.php
+++ b/software/var/www/header.php
@@ -63,7 +63,7 @@ if (isset($_SESSION["locale"])){
 	}
 ?>
 </head>
-<body onload="bildreload();garden()">
+<body onload="bildreload()">
 	<div id="wrapper">
 		<div id="header">
 			<div id="header_logo"><div class="header_link"><a href="../index.php"></a></div></div>

--- a/software/var/www/js/jquery.image.reload.js
+++ b/software/var/www/js/jquery.image.reload.js
@@ -39,6 +39,5 @@
 
 	function reload_body() {
        bildreload();
-       garden();
 	   raspicam();
     }


### PR DESCRIPTION
as stated here: https://www.grillsportverein.de/forum/threads/supportthread-zum-wlan-thermometer-mit-dem-raspberry-pi.190785/page-199#post-3244450

this removes the "garden()" what currently only gives errors.