### PR TITLE
Remove call to non existing "garden()"

### DIFF
--- a/software/var/www/js/jquery.image.reload.js
+++ b/software/var/www/js/jquery.image.reload.js
@@ -39,6 +39,5 @@
 
 	function reload_body() {
        bildreload();
-       garden();
 	   raspicam();
     }


### PR DESCRIPTION
as stated here: https://www.grillsportverein.de/forum/threads/supportthread-zum-wlan-thermometer-mit-dem-raspberry-pi.190785/page-199#post-3244450

this removes the "garden()" what currently only gives errors.